### PR TITLE
ability to use normal URL instead of sheetId only

### DIFF
--- a/src/Sheetsu.php
+++ b/src/Sheetsu.php
@@ -12,7 +12,7 @@ use Sheetsu\Interfaces\ModelInterface;
 
 final class Sheetsu
 {
-    const BASE_URL = 'https://sheetsu.com/apis/v1.0/';
+    const BASE_URL = 'https://sheetsu.com/apis/v1.0op/';
     private $connection;
     private $sheetId;
     private $sheetUrl;
@@ -38,8 +38,13 @@ final class Sheetsu
         if ($this->_needsNewConnectionObject($config)) {
             $this->_setConnection($config);
         }
-        $this->_setSheetId($config['sheetId']);
-        $this->_setSheetUrl();
+
+        if (array_key_exists( 'sheetId' , $config )) {
+            $this->_setSheetId($config['sheetId']);
+            $this->_setSheetUrl();
+        } else if (array_key_exists( 'sheetAddress' , $config )) {
+             $this->sheetUrl = $config['sheetAddress'];
+        }
         return $this;
     }
 

--- a/src/Sheetsu.php
+++ b/src/Sheetsu.php
@@ -39,12 +39,7 @@ final class Sheetsu
             $this->_setConnection($config);
         }
 
-        if (array_key_exists( 'sheetId' , $config )) {
-            $this->_setSheetId($config['sheetId']);
-            $this->_setSheetUrl();
-        } else if (array_key_exists( 'sheetAddress' , $config )) {
-             $this->sheetUrl = $config['sheetAddress'];
-        }
+        $this->_setUrlFromConfig($config);
         return $this;
     }
 
@@ -66,14 +61,27 @@ final class Sheetsu
         $this->connection = new Connection($config);
     }
 
+    private function _setUrlFromConfig(array $config) {
+        if (array_key_exists( 'sheetId' , $config )) {
+            $this->_setSheetId($config['sheetId']);
+            $this->_setSheetUrl();
+        } else if (array_key_exists( 'sheetAddress' , $config )) {
+             $this->_setSheetUrl($config['sheetAddress']);
+        }
+    }
+
     private function _setSheetId($sheetId)
     {
         $this->sheetId = $sheetId;
     }
 
-    private function _setSheetUrl()
+    private function _setSheetUrl($url = null)
     {
-        $this->sheetUrl = self::BASE_URL . $this->sheetId;
+        if (!is_null($url)) {
+            $this->sheetUrl = self::BASE_URL . $this->sheetId;
+        } else {
+            $this->sheetUrl = $url;
+        }
     }
 
     public function _getSheetUrl()

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -55,7 +55,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
                     'key'    => 'MY_KEY',
                     'secret' => 'MY_SECRET',
                     'method' => 'get',
-                    'url'    => 'https://sheetsu.com/apis/v1.0/dc31e735c9ce',
+                    'url'    => 'https://sheetsu.com/apis/v1.0op/dc31e735c9ce',
                     'limit'  => 0,
                     'offset' => 0
                 ]

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -103,7 +103,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
                     'key'    => 'MY_KEY',
                     'secret' => 'MY_SECRET',
                     'method' => 'get',
-                    'url'    => 'https://sheetsu.com/apis/v1.0/asda123',
+                    'url'    => 'https://sheetsu.com/apis/v1.0op/asda123',
                     'limit'  => 0,
                     'offset' => 0
                 ]
@@ -119,7 +119,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
                     'key'    => 'MY_KEY',
                     'secret' => 'MY_SECRET',
                     'method' => 'get',
-                    'url'    => 'https://sheetsu.com/apis/v1.0/dc31e735c9ce',
+                    'url'    => 'https://sheetsu.com/apis/v1.0op/dc31e735c9ce',
                     'limit'  => 0,
                     'offset' => 0
                 ]

--- a/tests/SheetsuTest.php
+++ b/tests/SheetsuTest.php
@@ -27,6 +27,18 @@ class SheetsuTest extends \PHPUnit_Framework_TestCase
         $collection = $response->getCollection();
         $this->assertTrue($collection instanceof Collection);
     }
+    /**
+     * @dataProvider validGetConfigProvider
+     */
+    public function testConstructSetsConnectionSheetAddressFromConfig($config)
+    {
+        $sheetsu = new Sheetsu([
+            'sheetAddress' => $config['sheetAddress']
+        ]);
+        $response = $sheetsu->read();
+        $collection = $response->getCollection();
+        $this->assertTrue($collection instanceof Collection);
+    }
 
     /**
      * @dataProvider validGetConfigProvider
@@ -182,6 +194,7 @@ class SheetsuTest extends \PHPUnit_Framework_TestCase
             [
                 [
                     'method'      => 'get',
+                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0/dc31e735c9ce',
                     'sheetId'     => 'dc31e735c9ce',
                     'limit'       => 0,
                     'offset'      => 0,
@@ -192,6 +205,7 @@ class SheetsuTest extends \PHPUnit_Framework_TestCase
             [
                 [
                     'method'      => 'get',
+                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0/dc31e735c9ce',
                     'sheetId'     => 'dc31e735c9ce',
                     'limit'       => 1,
                     'offset'      => 0,
@@ -202,6 +216,7 @@ class SheetsuTest extends \PHPUnit_Framework_TestCase
             [
                 [
                     'method'      => 'get',
+                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0/dc31e735c9ce',
                     'sheetId'     => 'dc31e735c9ce',
                     'limit'       => 1,
                     'offset'      => 1,

--- a/tests/SheetsuTest.php
+++ b/tests/SheetsuTest.php
@@ -140,7 +140,7 @@ class SheetsuTest extends \PHPUnit_Framework_TestCase
             'sheetId' => 'dc31e735c9ce'
         ]);
         $sheetsu->sheet('sheet2');
-        $this->assertEquals($sheetsu->_getSheetUrl(), 'https://sheetsu.com/apis/v1.0/dc31e735c9ce/sheets/sheet2');
+        $this->assertEquals($sheetsu->_getSheetUrl(), 'https://sheetsu.com/apis/v1.0op/dc31e735c9ce/sheets/sheet2');
     }
 
     public function testReadFromSpecificSheet()
@@ -194,7 +194,7 @@ class SheetsuTest extends \PHPUnit_Framework_TestCase
             [
                 [
                     'method'      => 'get',
-                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0/dc31e735c9ce',
+                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0op/dc31e735c9ce',
                     'sheetId'     => 'dc31e735c9ce',
                     'limit'       => 0,
                     'offset'      => 0,
@@ -205,7 +205,7 @@ class SheetsuTest extends \PHPUnit_Framework_TestCase
             [
                 [
                     'method'      => 'get',
-                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0/dc31e735c9ce',
+                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0op/dc31e735c9ce',
                     'sheetId'     => 'dc31e735c9ce',
                     'limit'       => 1,
                     'offset'      => 0,
@@ -216,7 +216,7 @@ class SheetsuTest extends \PHPUnit_Framework_TestCase
             [
                 [
                     'method'      => 'get',
-                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0/dc31e735c9ce',
+                    'sheetAddress'=> 'https://sheetsu.com/apis/v1.0op/dc31e735c9ce',
                     'sheetId'     => 'dc31e735c9ce',
                     'limit'       => 1,
                     'offset'      => 1,


### PR DESCRIPTION
Hi there! 
It's Bartek from Sheetsu here. We are in the middle of setting up different analytics measures for our application. The plan includes measuring a number of hits from different languages and libraries. We want to know where our users are and where our attention should be. That is why I made following changes: 

1. I have added ability to use URL instead of only Sheetsu id
2. Changed a base URL so we can track from which library the request is coming
