### PR TITLE
Fix url generation from sheet id

### DIFF
--- a/src/Sheetsu.php
+++ b/src/Sheetsu.php
@@ -77,7 +77,7 @@ final class Sheetsu
 
     private function _setSheetUrl($url = null)
     {
-        if (!is_null($url)) {
+        if (is_null($url)) {
             $this->sheetUrl = self::BASE_URL . $this->sheetId;
         } else {
             $this->sheetUrl = $url;

--- a/src/Sheetsu.php
+++ b/src/Sheetsu.php
@@ -16,6 +16,7 @@ final class Sheetsu
     private $connection;
     private $sheetId;
     private $sheetUrl;
+    private $documentUrl;
 
     /**
      * Sheetsu constructor. Instantiates Connection object with given config
@@ -81,6 +82,7 @@ final class Sheetsu
             $this->sheetUrl = self::BASE_URL . $this->sheetId;
         } else {
             $this->sheetUrl = $url;
+            $this->documentUrl = $url;
         }
     }
 
@@ -98,7 +100,11 @@ final class Sheetsu
     public function sheet($sheet)
     {
         if (trim($sheet) !== '') {
-            $this->sheetUrl .= '/sheets/' . trim($sheet);
+            if (isset($this->sheetId)) {
+                $this->sheetUrl = Sheetsu::BASE_URL . $this->sheetId . '/sheets/' . trim($sheet);
+            } else {
+                $this->sheetUrl = $this->documentUrl . '/sheets/' . trim($sheet);
+            }
         }
         return $this;
     }


### PR DESCRIPTION
Hi,

The current version of the client is not able to generate a sheet url based on sheet ID, I found that the bug was introduced in this PR :

 https://github.com/emilianozublena/sheetsu-php/commit/ea5c495cb635189c21df941b9413dc5a221db749


exactly in the condition of the following method :


```
private function _setSheetUrl($url = null)   {
 if (!is_null($url)) {

            $this->sheetUrl = self::BASE_URL . $this->sheetId;

        } else {

            $this->sheetUrl = $url;

        }
    }
```
